### PR TITLE
Respuestas Base para API

### DIFF
--- a/app/Http/Controllers/API/TestController.php
+++ b/app/Http/Controllers/API/TestController.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use Illuminate\Http\Request;
+use App\Http\Controllers\Controller;
+use App\Http\Controllers\ApiController;
+use Symfony\Component\HttpFoundation\Response;
+
+class TestController extends ApiController
+{
+	/**
+	 * @return \Illuminate\Http\JsonResponse
+	 */
+	public function test() {
+
+		return $this->setStatusCode(Response::HTTP_OK)->respond(['data' => 'esta es una prueba']);
+	}
+}

--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiController extends Controller
+{
+	/**
+	 * @var int
+     */
+	protected $statusCode = 200;
+
+	/**
+	 * @return mixed
+	 */
+	public function getStatusCode()
+	{
+		return $this->statusCode;
+	}
+
+	/**
+	 * @param mixed $statusCode
+	 * @return $this
+	 */
+	public function setStatusCode($statusCode)
+	{
+		$this->statusCode = $statusCode;
+
+		return $this;
+	}
+
+	/**
+	 * @param $data
+	 * @param array $headers
+	 * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     */
+	public function respond($data, $headers = [])
+	{
+		return response($data, $this->getStatusCode(), $headers);
+	}
+
+	/**
+	 * @param $message
+	 * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     */
+	public function respondWithError($message)
+	{
+		return $this->respond([
+			'error' => [
+				'message' => $message,
+				'status_code' => $this->getStatusCode()
+			]
+		]);
+	}
+
+	/**
+	 * @param $message
+	 * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+	 */
+	public function responseCreated($message)
+	{
+		return $this->setStatusCode(Response::HTTP_CREATED)
+			->respond([
+			'message' => $message
+		]);
+	}
+
+	/**
+	 * @param string $message
+	 * @return \Illuminate\Contracts\Routing\ResponseFactory|Response
+	 */
+	public function responseOK($message = 'success')
+	{
+		return $this->setStatusCode(Response::HTTP_OK)
+			->respond([
+			'message' => $message
+		]);
+	}
+
+	/**
+	 * @param string $message
+	 * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     */
+	public function respondBadRequest($message = 'The request cannot be fulfilled due to bad syntax')
+	{
+		return $this->setStatusCode(Response::HTTP_BAD_REQUEST)
+			->respondWithError($message);
+	}
+
+	/**
+	 * @param string $message
+	 * @return \Illuminate\Contracts\Routing\ResponseFactory|Response
+	 */
+	public function respondFailedParametersValidation($message = 'Paramaters failed validation for a user.')
+	{
+		return $this->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY)
+			->respondWithError($message);
+	}
+
+	/**
+	 * @param string $message
+	 * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     */
+	public function respondNotFound($message = 'Not Found!')
+	{
+		return $this->setStatusCode(Response::HTTP_NOT_FOUND)
+			->respondWithError($message);
+	}
+
+	/**
+	 * @param string $message
+	 * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
+     */
+	public function respondInternalError($message = 'Internal Error!')
+	{
+		return $this->setStatusCode(Response::HTTP_INTERNAL_SERVER_ERROR)
+			->respondWithError($message);
+	}
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -13,6 +13,6 @@ use Illuminate\Http\Request;
 |
 */
 
-Route::middleware('auth:api')->get('/user', function (Request $request) {
-    return $request->user();
+Route::group(['prefix' => 'v1', 'namespace' => 'API'], function() {
+	Route::get('/prueba', 'TestController@test');
 });


### PR DESCRIPTION
Se agrega controlador base con respuestas REST, además se agrega controlador TestController con namespace apuntando a directorio API, para extender controlador base y probar respuestas. 