### PR TITLE
Hotfix/social login

### DIFF
--- a/app/Http/Controllers/API/UsersController.php
+++ b/app/Http/Controllers/API/UsersController.php
@@ -135,6 +135,11 @@ class UsersController extends ApiController
             return $this->respondFailedParametersValidation('Uno o más parámetros no son válidos.');
         }
 
+        $validateToken = $this->checkFBToken($request);
+        if (!$validateToken) {
+           return $this->respondFailedParametersValidation('Uno o más parámetros no son válidos.'); 
+        }
+
         $match = [
             'avatar' => $request->avatar,
             'name' => $request->name,
@@ -193,5 +198,13 @@ class UsersController extends ApiController
             'token_type' => 'Bearer',
             'expires_at' => Carbon::parse($tokenResult->token->expires_at)->toDateTimeString()
         ];
+    }
+
+    private function checkFBToken($request)
+    {
+        $encryptedToken = md5($request->facebookId.$request->email.'gratis');
+        $response = !strcmp($encryptedToken, $request->facebookToken);
+
+        return $response;
     }
 }

--- a/tests/Feature/UserLoginSocialApiTest.php
+++ b/tests/Feature/UserLoginSocialApiTest.php
@@ -19,6 +19,22 @@ class UserLoginSocialApiTest extends TestCase
 		$response->assertStatus(422);
 	}
 
+    /** @test */
+    public function it_throws_facebookToken_mismatch()
+    {
+        $response = $this->post('api/v1/users/login/facebook');
+
+        $data = [
+            'email' => $this->faker->freeEmail(),
+            'name'  => $this->faker->name,
+            'facebookId' => $this->faker->md5,
+            'facebookToken' => $this->faker->md5,
+            'avatar' => 'https://picsum.photos/600'
+        ];
+
+        $response->assertStatus(422);
+    }
+
 	/** @test */
 	public function logins_existing_user()
 	{
@@ -32,11 +48,14 @@ class UserLoginSocialApiTest extends TestCase
             ]
         );
 
+        $facebookId = $this->faker->md5;
+        $facebookToken = md5($facebookId.$user->email.'gratis');
+
         $data = [
         	'email' => $user->email,
         	'name'  => $this->faker->name,
-        	'facebookId' => $this->faker->md5,
-        	'facebookToken' => $this->faker->md5,
+        	'facebookId' => $facebookId,
+        	'facebookToken' => $facebookToken,
         	'avatar' => 'https://picsum.photos/600'
         ];
 
@@ -48,12 +67,16 @@ class UserLoginSocialApiTest extends TestCase
 	/** @test */
 	public function logins_and_create_user()
 	{
+        $email      = $this->faker->freeEmail();
+        $facebookId = $this->faker->md5;
+        $facebookToken = md5($facebookId.$email.'gratis');
+
         $data = [
-        	'email' => $this->faker->freeEmail(),
-        	'name'  => $this->faker->name,
-        	'facebookId' => $this->faker->md5,
-        	'facebookToken' => $this->faker->md5,
-        	'avatar' => 'https://picsum.photos/600'
+        	'email' => $email,
+            'name'  => $this->faker->name,
+            'facebookId' => $facebookId,
+            'facebookToken' => $facebookToken,
+            'avatar' => 'https://picsum.photos/600'
         ];
 
 		$response = $this->post('api/v1/users/login/facebook', $data);


### PR DESCRIPTION
Tuve que modificar el login social nuevamente, porque:

- Cuando iniciamos sesión desde facebook, este devuelve facebookId, nombre, email y el avatar.
- Me dí cuenta que cualquiera puede crear usuarios con esos campos y tiene muy poca seguridad.
- Por lo mismo, decidí tomar el id, email y una semilla (la palabra gratis) y encriptarla con md5. Ese dato se envía como "facebookToken", la API hace el mismo ejercicio, toma el id y email recibido en el request más la semilla gratis, enctripta y compara ambos resultados.

Debemos darle una vuelta también al crear usuarios normal, debemos encargarnos de mandar un correo para verificar la cuenta, en caso contrario nos vamos a la B

<3